### PR TITLE
add OS name as Hetzner server label

### DIFF
--- a/agents.tf
+++ b/agents.tf
@@ -36,7 +36,7 @@ module "agents" {
   network_id                   = data.hcloud_network.k3s.id
   private_ipv4                 = cidrhost(hcloud_network_subnet.agent[[for i, v in var.agent_nodepools : i if v.name == each.value.nodepool_name][0]].ip_range, each.value.index + 101)
 
-  labels = merge(local.labels, local.labels_agent_node)
+  labels = merge(local.labels, local.labels_agent_node, { os = each.value.os })
 
   automatically_upgrade_os = var.automatically_upgrade_os
 

--- a/control_planes.tf
+++ b/control_planes.tf
@@ -39,7 +39,7 @@ module "control_planes" {
   # It leaves the subnet with 254 x 254 - 100 = 64416 IPs to use, so probably enough.
   private_ipv4 = cidrhost(hcloud_network_subnet.control_plane[[for i, v in var.control_plane_nodepools : i if v.name == each.value.nodepool_name][0]].ip_range, each.value.index + 101)
 
-  labels = merge(local.labels, local.labels_control_plane_node)
+  labels = merge(local.labels, local.labels_control_plane_node , { os = each.value.os })
 
   automatically_upgrade_os = var.automatically_upgrade_os
 


### PR DESCRIPTION
Makes it easier to remember/spot which nodes are running which OS.